### PR TITLE
Refactor SetWriter function to allow resetting output to os.Stdout

### DIFF
--- a/exception/exception.go
+++ b/exception/exception.go
@@ -24,9 +24,14 @@ var (
 )
 
 // SetWriter replaces the output target for debug/exception messages.
+// Pass nil to reset to os.Stdout.
 func SetWriter(w io.Writer) {
 	devWriterMu.Lock()
-	devWriter = w
+	if w == nil {
+		devWriter = os.Stdout
+	} else {
+		devWriter = w
+	}
 	devWriterMu.Unlock()
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,29 +1,27 @@
 package utils
 
 import (
-	"io/ioutil"
-	"os"
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/kun/exception"
 	"github.com/yaoapp/kun/maps"
 )
 
 func TestDump(t *testing.T) {
-	rescueStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
+	var buf bytes.Buffer
+	exception.SetWriter(&buf)
+	defer exception.SetWriter(nil) // reset to os.Stdout via GetWriter fallback
+
 	Dump(maps.Str{
 		"foo": "bar",
 		"nested": maps.Str{
 			"foo": "bar",
 		},
 	})
-	w.Close()
-	out, _ := ioutil.ReadAll(r)
-	os.Stdout = rescueStdout
-	assert.True(t, strings.Contains(string(out), "foo"), "the command return value should be have foo...")
+	assert.True(t, strings.Contains(buf.String(), "foo"), "the command return value should be have foo...")
 }
 
 func TestDumpString(t *testing.T) {


### PR DESCRIPTION
- Updated SetWriter to accept nil as an argument to reset the output target to os.Stdout.
- Modified unit tests to utilize a buffered writer for capturing output during tests, ensuring consistent logging behavior.